### PR TITLE
fix(DbRoute): fix findOne action name

### DIFF
--- a/src/Library/DbRoute.ts
+++ b/src/Library/DbRoute.ts
@@ -6,7 +6,7 @@ export class DbRoute {
   }
 
   public static findOne (endpoint: string, controller: string | { new (): Object }) {
-    return Route.get(`${endpoint}/:id`, controller, 'find');
+    return Route.get(`${endpoint}/:id`, controller, 'findOne');
   }
 
   public static create (endpoint: string, controller: string | { new (): Object }) {


### PR DESCRIPTION
DbRoute was pointing to `find` action in the controller, instead of `findOne`.